### PR TITLE
Fix Gradle for android studio 3.0 and Kotlin version 1.1.60

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.0.5-2'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.60'
   }
 }
 
@@ -13,7 +13,7 @@ apply plugin: 'kotlin-android'
 
 android {
   compileSdkVersion 25
-  buildToolsVersion '25.0.2'
+  buildToolsVersion '26.0.2'
 
   defaultConfig {
     applicationId 'com.fernandocejas.android.sample'
@@ -74,22 +74,22 @@ afterEvaluate {
 }
 
 dependencies {
-  compile 'io.reactivex.rxjava2:rxjava:2.0.2'
-  compile 'com.google.code.gson:gson:2.4'
-  compile 'com.android.support:appcompat-v7:25.1.0'
-  compile 'com.android.support:design:25.1.0'
-  compile "org.jetbrains.kotlin:kotlin-stdlib:1.0.6"
+  implementation 'io.reactivex.rxjava2:rxjava:2.0.2'
+  implementation 'com.google.code.gson:gson:2.4'
+  implementation 'com.android.support:appcompat-v7:25.1.0'
+  implementation 'com.android.support:design:25.1.0'
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:1.0.6"
 
-  testCompile 'junit:junit:4.12'
-  testCompile "org.robolectric:robolectric:3.2.1"
-  testCompile 'org.jetbrains.kotlin:kotlin-stdlib:1.0.6'
-  testCompile 'org.jetbrains.kotlin:kotlin-test-junit:1.0.6'
-  testCompile "com.nhaarman:mockito-kotlin:1.1.0"
-  testCompile 'org.amshove.kluent:kluent:1.14'
+  testImplementation 'junit:junit:4.12'
+  testImplementation "org.robolectric:robolectric:3.2.1"
+  testImplementation 'org.jetbrains.kotlin:kotlin-stdlib:1.0.6'
+  testImplementation 'org.jetbrains.kotlin:kotlin-test-junit:1.0.6'
+  testImplementation "com.nhaarman:mockito-kotlin:1.1.0"
+  testImplementation 'org.amshove.kluent:kluent:1.14'
 
-  androidTestCompile 'com.android.support.test:runner:0.5'
-  androidTestCompile 'com.android.support.test:rules:0.5'
-  androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-  androidTestCompile 'com.android.support.test.espresso:espresso-intents:2.2.2'
-  androidTestCompile 'com.android.support:support-annotations:25.1.0'
+  androidTestImplementation 'com.android.support.test:runner:0.5'
+  androidTestImplementation 'com.android.support.test:rules:0.5'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-core:2.2.2'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-intents:2.2.2'
+  androidTestImplementation 'com.android.support:support-annotations:25.1.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,16 @@
 buildscript {
   repositories {
+    google()
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.2'
+    classpath 'com.android.tools.build:gradle:3.0.0'
   }
 }
 
 allprojects {
   repositories {
+    google()
     jcenter()
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jan 08 19:14:53 ART 2017
+#Fri Nov 24 08:55:32 ICT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
## fix project refresh failed >> Error DependencyContainer
# configuration root project 
 - classpath gradle:3.0.0
 - add google() to repositories
# configuration app
 - 'compile' in project  ':app'  is deprecated Use 'implementation' instead
 - 'testCompile' in project  ':app'  is deprecated Use 'testImplementation' instead
 - 'androidTestCompile' in project  ':app'  is deprecated Use 'androidTestImplementation' instead
 - and update Android SDK Build Tools version 25.0.2 to below the minimum supported 26.0.2 for Android Gradle Plugin 3.0.0 Android SDK Build Tools 26.0.2 will be used.